### PR TITLE
Use chamfer when constructing shapes with rounded corners

### DIFF
--- a/converter/convert.js
+++ b/converter/convert.js
@@ -42,18 +42,22 @@ function getElementProperties(element){
 
   var angle = Math.atan2(b, a); //angle in rad
 
-  console.log('Height:   ' + x);
-  console.log('Width:    ' + y);
-  console.log('X:        ' + x);
-  console.log('Y:        ' + y);
-  console.log('Scale:    ' + scale);
-  console.log('Rotation: ' + (angle * (180/3.14159)));
+  var borderRadius = Number(styles.borderRadius.match(/\d+/)) || 0;
+
+  console.log('Height:        ' + x);
+  console.log('Width:         ' + y);
+  console.log('X:             ' + x);
+  console.log('Y:             ' + y);
+  console.log('Scale:         ' + scale);
+  console.log('Rotation:      ' + (angle * (180/3.14159)));
+  console.log('Border Radius: ' + borderRadius);
 
   return {
-    height: height, // Height
-    width: width,   // Width
-    x: x,           // X (center)
-    y: y,           // Y (center)
-    angle: angle    // Angle in radians
+    height: height,               // Height
+    width: width,                 // Width
+    x: x,                         // X (center)
+    y: y,                         // Y (center)
+    angle: angle,                  // Angle in radians
+    borderRadius: borderRadius    // Radius in px
   }
 }

--- a/converter/test.js
+++ b/converter/test.js
@@ -36,10 +36,16 @@
 
       var props = getElementProperties(element);
 
-      var object = Bodies.rectangle(props.x, props.y, props.width, props.height, {
+      var options = {
         isStatic: static,
         angle: props.angle,
-      });
+      };
+
+      // The existence of "chamfer" at all on the option object will cause it to round corners a little (bug in matter?).
+      // So, only apply it when necessary.
+      if (props.borderRadius > 0) options.chamfer = { radius: props.borderRadius };
+
+      var object = Bodies.rectangle(props.x, props.y, props.width, props.height, options);
 
       element.physics = object;
 


### PR DESCRIPTION
Detect `border-radius` in converter and only apply it to physics shapes when it's > 0. This is a little clunky. Might want to have another way to create shapes in our engine that knows about little exceptions like the one [here](https://github.com/secretrobotron/games/compare/rounded-corners?expand=1#diff-5b4d7a8cd6e7fbdfbb3937eee3d4f831R46) to avoid nonsense.