### PR TITLE
Load music/sound before doing anything else.

### DIFF
--- a/battle-pong/src/js/music.js
+++ b/battle-pong/src/js/music.js
@@ -256,9 +256,12 @@
     };
 
     this.fadeOut = function (duration) {
-      return currentSong.fadeOut(duration).then(() => {
-        this.status = 'stopped';
-      });
+      if (currentSong) {
+        return currentSong.fadeOut(duration).then(() => {
+          this.status = 'stopped';
+        });
+      }
+      return null;
     };
 
     this.getSettingsForOutput = function () {

--- a/battle-pong/src/js/rules.js
+++ b/battle-pong/src/js/rules.js
@@ -3,66 +3,66 @@ const rulenames = [];
 let ruleNavEls;
 
 document.addEventListener('DOMContentLoaded', function () {
-
-  setupNavButtons();
-
-  ruleNavEls = document.querySelectorAll(".rules-nav a");
-  ruleNavEls.forEach(function(el){
-    let type = el.getAttribute("nav");
-    rulenames.push(type);
-
-    el.addEventListener("click",function(e){
-      let type = this.getAttribute("nav");
-      showRule(type);
-      SoundManager.playSound("ui");
-      addTemporaryClassName(e.target, "poke", 250);
-      e.preventDefault();
-    })
-  });
-
-  ruleEls = document.querySelectorAll(".rule-box");
-
-  document.querySelector(".button.previous").addEventListener("click",function(){
-    previousRule();
-    SoundManager.playSound("ui");
-    addTemporaryClassName(this, "poke", 250);
-  })
-  
-  document.querySelector(".button.next").addEventListener("click",function(){
-    addTemporaryClassName(this, "poke", 250);
-    SoundManager.playSound("ui");
-    nextRule();
-  })
-
-  numRules = ruleEls.length;
-
-  powerupEls = document.querySelectorAll(".powerup-row .icon");
-
-  powerupEls.forEach(function(el){
-    let type = el.getAttribute("type");
-    powerupnames.push(type);
-    el.addEventListener("click", function(el){
-      let type = this.getAttribute("type");
-      showPowerup(type);
-      SoundManager.playSound("ui");
-    });
-  })
-
-  showPowerup(powerupnames[0]);
-  currentRule = rulenames[0];
-  if (window.location.hash) {
-    let prospectiveRule = window.location.hash.substr(1);
-    if (rulenames.indexOf(prospectiveRule) > -1) {
-      currentRule = prospectiveRule;
-    }
-  }
-  showRule(currentRule);
-
-  // nextStep();
-  setupInputButtons();
-  selectButtonByIndex(12);
-
   SoundManager.init().then(() => {
+
+    setupNavButtons();
+
+    ruleNavEls = document.querySelectorAll(".rules-nav a");
+    ruleNavEls.forEach(function(el){
+      let type = el.getAttribute("nav");
+      rulenames.push(type);
+
+      el.addEventListener("click",function(e){
+        let type = this.getAttribute("nav");
+        showRule(type);
+        SoundManager.playSound("ui");
+        addTemporaryClassName(e.target, "poke", 250);
+        e.preventDefault();
+      })
+    });
+
+    ruleEls = document.querySelectorAll(".rule-box");
+
+    document.querySelector(".button.previous").addEventListener("click",function(){
+      previousRule();
+      SoundManager.playSound("ui");
+      addTemporaryClassName(this, "poke", 250);
+    })
+    
+    document.querySelector(".button.next").addEventListener("click",function(){
+      addTemporaryClassName(this, "poke", 250);
+      SoundManager.playSound("ui");
+      nextRule();
+    })
+
+    numRules = ruleEls.length;
+
+    powerupEls = document.querySelectorAll(".powerup-row .icon");
+
+    powerupEls.forEach(function(el){
+      let type = el.getAttribute("type");
+      powerupnames.push(type);
+      el.addEventListener("click", function(el){
+        let type = this.getAttribute("type");
+        showPowerup(type);
+        SoundManager.playSound("ui");
+      });
+    })
+
+    showPowerup(powerupnames[0]);
+    currentRule = rulenames[0];
+    if (window.location.hash) {
+      let prospectiveRule = window.location.hash.substr(1);
+      if (rulenames.indexOf(prospectiveRule) > -1) {
+        currentRule = prospectiveRule;
+      }
+    }
+    showRule(currentRule);
+
+    // nextStep();
+    setupInputButtons();
+    selectButtonByIndex(12);
+
     SoundManager.loadSettingsFromLocalStorage();
     SoundManager.musicEngine.cueSong('menu');
     SoundManager.musicEngine.fadeIn( 2, {loop: true} );

--- a/battle-pong/src/js/splash.js
+++ b/battle-pong/src/js/splash.js
@@ -10,34 +10,38 @@ let timeoutAccumulator = 0;
 
 document.addEventListener('DOMContentLoaded', function(){
   const CREDITS_DELAY = 3000;
-
-  paddles.push(createObject({noBody: true}));
-  paddles.push(createObject({noBody: true}));
-
-  initParticleEngine(".scene", 5);
-  loop();
-  
-  prepTitle();
-
-  bestOfEls = document.querySelectorAll(".best-of .option");
-  setupBestOf();
-
-  powerupEls = document.querySelectorAll(".powerups .powerup");
-  setupPowerups(powerupEls);
-
-  toggleEls = document.querySelectorAll(".option-toggle");
-  setupToggles(toggleEls);
-
-  playerOptionEls = document.querySelectorAll(".player-options .player-option");
-  setupPlayerOptionss(playerOptionEls);
-
-  setupStartButton();
-  setupRulesButton();
-
-  starsHeight = document.querySelector(".canvas-stars").getBoundingClientRect().height;
-  startStars(50, window.innerWidth, window.innerHeight);
-
   SoundManager.init().then(() => {
+    initParticleEngine(".scene", 5);
+    loop();
+    
+    prepTitle();
+
+    paddles.push(createObject({noBody: true}));
+    paddles.push(createObject({noBody: true}));
+
+    initParticleEngine(".scene", 5);
+    loop();
+    
+    prepTitle();
+
+    bestOfEls = document.querySelectorAll(".best-of .option");
+    setupBestOf();
+
+    powerupEls = document.querySelectorAll(".powerups .powerup");
+    setupPowerups(powerupEls);
+
+    toggleEls = document.querySelectorAll(".option-toggle");
+    setupToggles(toggleEls);
+
+    playerOptionEls = document.querySelectorAll(".player-options .player-option");
+    setupPlayerOptionss(playerOptionEls);
+
+    setupStartButton();
+    setupRulesButton();
+
+    starsHeight = document.querySelector(".canvas-stars").getBoundingClientRect().height;
+    startStars(50, window.innerWidth, window.innerHeight);
+
     SoundManager.loadSettingsFromLocalStorage();
     SoundManager.musicEngine.cueSong('menu');
     if (Settings.music) SoundManager.musicEngine.fadeIn( 2, {loop: true} );

--- a/battle-pong/src/js/splash.js
+++ b/battle-pong/src/js/splash.js
@@ -45,6 +45,8 @@ document.addEventListener('DOMContentLoaded', function(){
     SoundManager.loadSettingsFromLocalStorage();
     SoundManager.musicEngine.cueSong('menu');
     if (Settings.music) SoundManager.musicEngine.fadeIn( 2, {loop: true} );
+
+    setupInputs();
   });
 
   document.querySelector(".splash").classList.add("appear");
@@ -58,7 +60,6 @@ document.addEventListener('DOMContentLoaded', function(){
     updatePlayerOptions(playerOptionEls);
   });
 
-  setupInputs();
 });
 
 function setupInputs() {


### PR DESCRIPTION
For splash & rules, moved all init stuff into SoundManager.init callback.

@flukeout this fixes a couple of bugs and adds some smoothness because music can fade in before you're allowed to click any buttons. But, I'm not *super* happy with it because it makes you wait until music & sound has loaded before showing anything else. I think it would be ok if we fixed the animations and stuff to come up afterward as well, so things don't appear so suddenly.

What do you think?