### PR TITLE
Fixes pause scoring bug

### DIFF
--- a/battle-pong/src/js/game.js
+++ b/battle-pong/src/js/game.js
@@ -249,7 +249,7 @@ var game =  {
 
   run: function () {
     var g = this;
-    g.mode = 'startup';
+    // g.mode = 'startup';
     (function loop() {
 
       if(g.freezeFrames === 0) {


### PR DESCRIPTION
Fixes #182 

Every time we unpaused, it would put the game into `startup` state. I don't really see the startup state used anywhere anyway.

This fixes the bad bug we were seeing. The pause thing is flaky still though I think. If you pause right at the beginning after going to the game screen and unpause later, some things get messed up. I think cuz we are relying on some settimeouts to do stuff and they dont get cancelled. We could just let people pause during specific states to make things more resiliant.

cc @secretrobotron 